### PR TITLE
"each" validator loosing context

### DIFF
--- a/lib/schemator.js
+++ b/lib/schemator.js
@@ -103,12 +103,12 @@ Schemator.prototype.run = function(obj, callback){
                     var value = dotty.get(obj, validation[0]);
                     var args = Array.isArray(validation[2]) ? validation[2] : [validation[2]];
 
-                    context.key = validation[0];
+                    var contextCopy = Object.assign({}, context, {key: validation[0]});
 
                     if(!func)
                         return callback(new Error('Unknown validation method ' + validation[1]));
 
-                    func.call(context, value, args, function(err, inv, override){
+                    func.call(contextCopy, value, args, function(err, inv, override){
                         if(err)
                             return callback(err);
 
@@ -133,13 +133,13 @@ Schemator.prototype.run = function(obj, callback){
                     var value = dotty.get(obj, flag[0]);
                     var flagger = flaggers[flag[1]] || that.custom.flagger[flag[1]];
                     var args = Array.isArray(flag[2]) ? flag[2] : [flag[2]];
-
-                    var contextCopy = Object.assign({}, context, {key: validation[0]});
+                    
+                    context.key = flag[0];
 
                     if(!flagger)
                         return callback(new Error('Unknown flagger method ' + flag[1]));
 
-                    flagger.call(contextCopy, value, args, function(err){
+                    flagger.call(context, value, args, function(err){
                         callback(err);
                     });
                 });

--- a/lib/schemator.js
+++ b/lib/schemator.js
@@ -134,12 +134,12 @@ Schemator.prototype.run = function(obj, callback){
                     var flagger = flaggers[flag[1]] || that.custom.flagger[flag[1]];
                     var args = Array.isArray(flag[2]) ? flag[2] : [flag[2]];
 
-                    context.key = flag[0];
+                    var contextCopy = Object.assign({}, context, {key: validation[0]});
 
                     if(!flagger)
                         return callback(new Error('Unknown flagger method ' + flag[1]));
 
-                    flagger.call(context, value, args, function(err){
+                    flagger.call(contextCopy, value, args, function(err){
                         callback(err);
                     });
                 });


### PR DESCRIPTION
when you have fields in schema added after field with "each" validator, then errors from "each" validator are assigned to the last field's name from schema.

example:

``` javascript
var schema = new Schemator({
  books: {
    type : 'array',
    each : new Schemator({
      author : {
        type : 'string',
      }
    })
  },
  name : {
    type: 'string'
  }
});

var data = {
  books: [
    {}
  ],
  name : 'name'
};
```

result:
[ [ [ 'name', 0, 'author' ], 'type', 'author field didn\'t mach the type string.' ] ]

expected result:
[ [ [ 'books', 0, 'author' ], 'type', 'author field didn\'t mach the type string.' ] ]
